### PR TITLE
Prevent conflicts with React 0.14.0-rc1

### DIFF
--- a/lib/button/index.js
+++ b/lib/button/index.js
@@ -6,6 +6,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'd
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
+function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -14,9 +16,13 @@ var _style = require('./style');
 
 var _style2 = _interopRequireDefault(_style);
 
-var ManifestButton = (function () {
+var ManifestButton = (function (_React$Component) {
+  _inherits(ManifestButton, _React$Component);
+
   function ManifestButton() {
     _classCallCheck(this, ManifestButton);
+
+    _React$Component.apply(this, arguments);
   }
 
   ManifestButton.prototype.render = function render() {
@@ -32,7 +38,7 @@ var ManifestButton = (function () {
   };
 
   return ManifestButton;
-})();
+})(_react2['default'].Component);
 
 exports['default'] = ManifestButton;
 module.exports = exports['default'];

--- a/lib/style.js
+++ b/lib/style.js
@@ -6,6 +6,7 @@ exports['default'] = {
     fontFamily: 'Arial, sans-serif',
     fontSize: '13px',
     position: 'fixed',
+    color: 'black',
     top: 0,
     right: 0,
     bottom: 0,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "deep-diff": "^0.3.2",
     "mousetrap": "^1.5.3",
     "radium": "^0.13.5",
-    "react": "^0.13.3",
     "react-redux": "2.0.0",
     "redux": "2.0.0"
   }

--- a/src/button/index.js
+++ b/src/button/index.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import style from './style';
 
-export default class ManifestButton {
+export default class ManifestButton extends React.Component {
   render() {
     const { label, action } = this.props;
 


### PR DESCRIPTION
Should resolve https://github.com/whetstone/redux-devtools-diff-monitor/issues/13 (or does in my project anyway!)

react 0.14.0-rc1 and 0.13.0 on the page together didn't seem to play nice.

Safe assumption that users of redux-devtools-diff-monitor already have React available, so no need to bring in specific dependency.

Tweak to src/button/index.js to prevent warning when using react 0.14.0-rc1