### PR TITLE
Better diffs for ImmutableJS users

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,6 +30,10 @@ var _deepDiff = require('deep-diff');
 
 var _deepDiff2 = _interopRequireDefault(_deepDiff);
 
+var _immutable = require('immutable');
+
+var _immutable2 = _interopRequireDefault(_immutable);
+
 var _mousetrap = require('mousetrap');
 
 var _mousetrap2 = _interopRequireDefault(_mousetrap);
@@ -65,7 +69,7 @@ var ManifestComponent = (function (_React$Component) {
   };
 
   ManifestComponent.prototype.componentWillUnmount = function componentWillUnmount() {
-    Mousetrap.unbind(['ctrl+h', 'ctrl+]']);
+    Mousetrap.unbind(this.props.shortcut || ['ctrl+h', 'ctrl+]']);
   };
 
   ManifestComponent.prototype.render = function render() {
@@ -96,8 +100,8 @@ var ManifestComponent = (function (_React$Component) {
         oldState = undefined,
         diff = undefined;
     if (index !== 0) {
-      newState = this.props.computedStates[index].state;
-      oldState = this.props.computedStates[index - 1].state;
+      newState = _immutable2['default'].Map(this.props.computedStates[index].state).toJS();
+      oldState = _immutable2['default'].Map(this.props.computedStates[index - 1].state).toJS();
       diff = _deepDiff2['default'].diff(oldState, newState);
     }
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "deep-diff": "^0.3.2",
+    "immutable": "3.7.5",
     "mousetrap": "^1.5.3",
     "radium": "^0.13.5",
     "react-redux": "2.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import ManifestAction from './action';
 import ManifestButton from './button';
 
 import deep from 'deep-diff';
+import Immutable from 'immutable';
 import mousetrap from 'mousetrap';
 
 import style from './style';
@@ -74,8 +75,8 @@ class ManifestComponent extends React.Component {
   renderAction(action, index) {
     let newState, oldState, diff;
     if (index !== 0) {
-      newState = this.props.computedStates[index].state;
-      oldState = this.props.computedStates[index - 1].state;
+      newState = Immutable.Map(this.props.computedStates[index].state).toJS();
+      oldState = Immutable.Map(this.props.computedStates[index - 1].state).toJS();
       diff = deep.diff(oldState, newState);
     }
 


### PR DESCRIPTION
When using ImmutableJS, the diffs in DiffMonitor aren't as useful as they are when dealing with raw objects.

![screen shot on 2015-09-23 at 11-50-11](https://cloud.githubusercontent.com/assets/429802/10043748/54361ad4-61ed-11e5-9d68-722f77e8d870.png)

The PR allows ImmutableJS users to get better information about changed state in the diffs:

![screen shot on 2015-09-23 at 11-49-21](https://cloud.githubusercontent.com/assets/429802/10043778/8de899d2-61ed-11e5-94db-0add7a22e352.png)

I've tested against non-ImmutableJS state and a few different nestings of raw and ImmutableJS objects and this still all seems to work ok.

It is a bit of a shame to bring in Immutable to this package and run all diffs through it even if a user isn't using ImmutableJS, but there are probably enough people using it to make this a worthwhile change.