### PR TITLE
Ensure works with modifying, deleting and changing items in arrays

### DIFF
--- a/lib/action/index.js
+++ b/lib/action/index.js
@@ -24,66 +24,94 @@ var ManifestActionComponent = (function (_React$Component) {
   _inherits(ManifestActionComponent, _React$Component);
 
   function ManifestActionComponent() {
-    var _this = this;
-
     _classCallCheck(this, ManifestActionComponent);
 
     _React$Component.call(this);
-
-    this.getDiffs = function () {
-      var diff = _this.props.diff;
-
-      return diff.map(function (d, i) {
-        return _this.renderDiff(d, i);
-      });
-    };
-
-    this.expandAction = function () {
-      _this.setState({
-        expanded: !_this.state.expanded
-      });
-    };
-
-    this.disableAction = function () {
-      _this.props.toggleAction(_this.props.index);
-    };
-
-    this.renderDiff = function (diff, index) {
-      var oldValue = JSON.stringify(diff.lhs);
-      var newValue = JSON.stringify(diff.rhs);
-
-      return _react2['default'].createElement(
-        'div',
-        { key: index },
-        diff.path.join('.'),
-        ': ',
-        _react2['default'].createElement(
-          'span',
-          { style: _style2['default'].oldValue },
-          oldValue || 'undefined'
-        ),
-        _react2['default'].createElement(
-          'span',
-          { style: _style2['default'].newValue },
-          ' ',
-          newValue,
-          ' '
-        )
-      );
-    };
-
     this.state = {
       expanded: false
     };
   }
+
+  ManifestActionComponent.prototype.getDiffs = function getDiffs() {
+    var _this = this;
+
+    var diff = this.props.diff;
+
+    return diff.map(function (d, i) {
+      return _this.renderDiff(d, i);
+    });
+  };
+
+  ManifestActionComponent.prototype.expandAction = function expandAction() {
+    this.setState({
+      expanded: !this.state.expanded
+    });
+  };
+
+  ManifestActionComponent.prototype.disableAction = function disableAction() {
+    this.props.toggleAction(this.props.index);
+  };
+
+  ManifestActionComponent.prototype.createOldValue = function createOldValue(diff) {
+    if (diff.item) {
+      return JSON.stringify(diff.item.lhs);
+    } else {
+      return JSON.stringify(diff.lhs);
+    }
+  };
+
+  ManifestActionComponent.prototype.createNewValue = function createNewValue(diff) {
+    if (diff.item) {
+      return JSON.stringify(diff.item.rhs);
+    } else {
+      return JSON.stringify(diff.rhs);
+    }
+  };
+
+  ManifestActionComponent.prototype.createPath = function createPath(diff) {
+    var path = [];
+
+    if (diff.path) {
+      path = path.concat(diff.path);
+    }
+    if (typeof diff.index !== 'undefined') {
+      path.push(diff.index);
+    }
+    return path.length ? path.join('.') : '';
+  };
+
+  ManifestActionComponent.prototype.renderDiff = function renderDiff(diff, index) {
+    var oldValue = this.createOldValue(diff);
+    var newValue = this.createNewValue(diff);
+    var path = this.createPath(diff);
+
+    return _react2['default'].createElement(
+      'div',
+      { key: index },
+      path,
+      ': ',
+      _react2['default'].createElement(
+        'span',
+        { style: _style2['default'].oldValue },
+        oldValue || 'undefined'
+      ),
+      _react2['default'].createElement(
+        'span',
+        { style: _style2['default'].newValue },
+        ' ',
+        newValue,
+        ' '
+      )
+    );
+  };
 
   ManifestActionComponent.prototype.render = function render() {
     var _props = this.props;
     var action = _props.action;
     var diff = _props.diff;
     var skipped = _props.skipped;
-    var expanded = this.state.expanded;
 
+    var expanded = this.props.expanded || this.state.expanded;
     var storeHasChanged = !!diff.length;
     var changes = this.getDiffs();
 
@@ -111,7 +139,10 @@ var ManifestActionComponent = (function (_React$Component) {
       ),
       _react2['default'].createElement(
         'pre',
-        { style: _style2['default'].store },
+        {
+          className: 'diff',
+          style: _style2['default'].store
+        },
         changes
       )
     ) : null;
@@ -120,15 +151,16 @@ var ManifestActionComponent = (function (_React$Component) {
 
     return _react2['default'].createElement(
       'div',
-      null,
+      { className: 'manifest-action-component' },
       _react2['default'].createElement(
         'div',
         { style: _style2['default'].base },
         _react2['default'].createElement(
           'div',
           {
+            className: action.type,
             style: [_style2['default'].title, diff.length && _style2['default'].mutated, skipped && _style2['default'].skipped],
-            onClick: this.expandAction
+            onClick: this.expandAction.bind(this)
           },
           _react2['default'].createElement(
             'span',
@@ -137,7 +169,7 @@ var ManifestActionComponent = (function (_React$Component) {
           ),
           _react2['default'].createElement(
             'span',
-            { style: _style2['default'].toggle, onClick: this.disableAction },
+            { style: _style2['default'].toggle, onClick: this.disableAction.bind(this) },
             enableToggle
           )
         ),

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,13 +26,9 @@ var _button = require('./button');
 
 var _button2 = _interopRequireDefault(_button);
 
-var _deepDiff = require('deep-diff');
+var _utilsDiffState = require('./utils/diff-state');
 
-var _deepDiff2 = _interopRequireDefault(_deepDiff);
-
-var _immutable = require('immutable');
-
-var _immutable2 = _interopRequireDefault(_immutable);
+var _utilsDiffState2 = _interopRequireDefault(_utilsDiffState);
 
 var _mousetrap = require('mousetrap');
 
@@ -58,7 +54,7 @@ var ManifestComponent = (function (_React$Component) {
 
   ManifestComponent.prototype.componentDidMount = function componentDidMount() {
     var self = this;
-    Mousetrap.bind(this.props.shortcut || ['ctrl+h', 'ctrl+]'], function (e) {
+    window.Mousetrap.bind(this.props.shortcut || ['ctrl+h', 'ctrl+]'], function (e) {
       self.toggleVisibility();
       return false;
     });
@@ -69,7 +65,7 @@ var ManifestComponent = (function (_React$Component) {
   };
 
   ManifestComponent.prototype.componentWillUnmount = function componentWillUnmount() {
-    Mousetrap.unbind(this.props.shortcut || ['ctrl+h', 'ctrl+]']);
+    window.Mousetrap.unbind(this.props.shortcut || ['ctrl+h', 'ctrl+]']);
   };
 
   ManifestComponent.prototype.render = function render() {
@@ -96,21 +92,13 @@ var ManifestComponent = (function (_React$Component) {
   };
 
   ManifestComponent.prototype.renderAction = function renderAction(action, index) {
-    var newState = undefined,
-        oldState = undefined,
-        diff = undefined;
-    if (index !== 0) {
-      newState = _immutable2['default'].Map(this.props.computedStates[index].state).toJS();
-      oldState = _immutable2['default'].Map(this.props.computedStates[index - 1].state).toJS();
-      diff = _deepDiff2['default'].diff(oldState, newState);
-    }
-
+    var diffedStates = _utilsDiffState2['default'](this.props.computedStates, index);
     var skippingAction = this.props.skippedActions[index] === true;
 
     return _react2['default'].createElement(_action2['default'], { action: action,
       index: index,
       key: index,
-      diff: diff || [],
+      diff: diffedStates,
       skipped: skippingAction,
       toggleAction: this.props.toggleAction.bind(this, index),
       jumpTo: this.jumpingTo.bind(this, index) });

--- a/lib/utils/diff-state.js
+++ b/lib/utils/diff-state.js
@@ -1,0 +1,34 @@
+'use strict';
+
+exports.__esModule = true;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _deepDiff = require('deep-diff');
+
+var _deepDiff2 = _interopRequireDefault(_deepDiff);
+
+var _immutable = require('immutable');
+
+var _immutable2 = _interopRequireDefault(_immutable);
+
+exports['default'] = function (computedStates, index) {
+  if (index !== 0) {
+
+    var newState = _immutable2['default'].fromJS({
+      state: computedStates[index].state
+    }).toJS().state;
+
+    var oldState = _immutable2['default'].fromJS({
+      state: computedStates[index - 1].state
+    }).toJS().state;
+
+    var diff = _deepDiff2['default'].diff(oldState, newState);
+
+    return diff || [];
+  } else {
+    return [];
+  }
+};
+
+module.exports = exports['default'];

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "babel src --out-dir lib",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "test": "mocha test/ --compilers js:babel/register"
   },
   "repository": "https://github.com/whetstone/redux-devtools-diff-monitor.git",
   "author": "iktl | gtfiorentino",
@@ -14,7 +15,11 @@
     "babel": "^5.5.8",
     "babel-core": "^5.6.18",
     "babel-eslint": "^3.1.15",
-    "babel-loader": "^5.1.4"
+    "babel-loader": "^5.1.4",
+    "chai": "^3.3.0",
+    "jsdom": "3.1.2",
+    "mocha": "^2.3.3",
+    "should": "^7.1.0"
   },
   "dependencies": {
     "deep-diff": "^0.3.2",

--- a/src/action/index.js
+++ b/src/action/index.js
@@ -10,80 +10,114 @@ class ManifestActionComponent extends React.Component {
     };
   }
 
-  getDiffs = () => {
+  getDiffs () {
     const { diff } = this.props;
+
     return diff.map((d,i) => this.renderDiff(d,i));
   }
 
-  expandAction = () => {
+  expandAction () {
     this.setState({
       expanded: !this.state.expanded
     });
   }
 
-  disableAction = () => {
+  disableAction () {
     this.props.toggleAction(this.props.index);
   }
 
-  renderDiff = (diff, index) => {
-    const oldValue = JSON.stringify(diff.lhs);
-    const newValue = JSON.stringify(diff.rhs);
+  createOldValue(diff) {
+    if (diff.item) {
+      return (JSON.stringify(diff.item.lhs));
+    } else {
+      return JSON.stringify(diff.lhs);
+    }
+  }
+
+  createNewValue(diff) {
+    if (diff.item) {
+      return (JSON.stringify(diff.item.rhs));
+    } else {
+      return JSON.stringify(diff.rhs);
+    }
+  }
+
+  createPath (diff) {
+    let path = [];
+
+    if (diff.path) {
+      path = path.concat(diff.path);
+    }
+    if (typeof(diff.index) !== 'undefined') {
+      path.push(diff.index);
+    }
+    return path.length ? path.join('.') : '';
+  }
+
+  renderDiff (diff, index) {
+    const oldValue = this.createOldValue(diff);
+    const newValue = this.createNewValue(diff);
+    const path = this.createPath(diff);
 
     return (
-      <div key={index}>
-        { diff.path.join('.') }: <span style={style.oldValue}>{ oldValue || 'undefined' }</span>
-        <span style={style.newValue}> { newValue } </span>
-      </div>
+        <div key={index}>
+          { path }: <span style={style.oldValue}>{ oldValue || 'undefined' }</span>
+          <span style={style.newValue}> { newValue } </span>
+        </div>
     );
   }
 
   render() {
     const { action, diff, skipped } = this.props;
-    const { expanded } = this.state;
+    const expanded = this.props.expanded || this.state.expanded;
     const storeHasChanged = !!diff.length;
     const changes         = this.getDiffs();
 
     const actionBlock = this.state.expanded ?
-      <div>
-        <pre style={style.actionData}>{JSON.stringify(action)}</pre>
-      </div> :
-      null;
+        <div>
+          <pre style={style.actionData}>{JSON.stringify(action)}</pre>
+        </div> :
+        null;
 
     const storeBlock = (expanded && storeHasChanged) ?
-      <div>
-        <div style={style.header}>
-          <span>Store Mutations</span>
-        </div>
-        <pre style={style.store}>
+        <div>
+          <div style={style.header}>
+            <span>Store Mutations</span>
+          </div>
+        <pre
+            className="diff"
+            style={style.store}
+            >
           {changes}
         </pre>
-      </div> :
-      null;
+        </div> :
+        null;
 
     const enableToggle = skipped ?
-      'enable' :
-      'disable';
+        'enable' :
+        'disable';
 
     return (
-      <div>
-        <div style={style.base}>
-          <div
-            style={[
-              style.title,
-              diff.length && style.mutated,
-              skipped && style.skipped,
-            ]}
-            onClick={this.expandAction}
-            >
-            <span>{action.type}</span>
-            <span style={style.toggle} onClick={this.disableAction}>
-              {enableToggle}
-            </span>
+        <div className="manifest-action-component">
+          <div style={style.base}>
+            <div
+                className={action.type}
+                style={[
+                  style.title,
+                  diff.length && style.mutated,
+                  skipped && style.skipped
+                ]}
+                onClick={this.expandAction.bind(this)}
+                >
+              <span>{action.type}</span>
+              <span style={style.toggle} onClick={this.disableAction.bind(this)}>
+                {enableToggle}
+              </span>
+            </div>
+            {actionBlock}
+            {storeBlock}
           </div>
-          {actionBlock}
-          {storeBlock}
         </div>
-      </div>
     );
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,7 @@ import Radium from 'radium';
 import ManifestAction from './action';
 import ManifestButton from './button';
 
-import deep from 'deep-diff';
-import Immutable from 'immutable';
+import diffState from './utils/diff-state';
 import mousetrap from 'mousetrap';
 
 import style from './style';
@@ -36,7 +35,7 @@ class ManifestComponent extends React.Component {
 
   componentDidMount() {
     const self = this;
-    Mousetrap.bind(this.props.shortcut || ['ctrl+h', 'ctrl+]'], function (e) {
+    window.Mousetrap.bind(this.props.shortcut || ['ctrl+h', 'ctrl+]'], function (e) {
       self.toggleVisibility();
       return false;
     });
@@ -47,7 +46,7 @@ class ManifestComponent extends React.Component {
   }
 
   componentWillUnmount() {
-    Mousetrap.unbind(this.props.shortcut || ['ctrl+h', 'ctrl+]']);
+    window.Mousetrap.unbind(this.props.shortcut || ['ctrl+h', 'ctrl+]']);
   }
 
   render() {
@@ -58,7 +57,7 @@ class ManifestComponent extends React.Component {
     return (
       <div style={[
           style.base,
-          visible && style.hidden,
+          visible && style.hidden
         ]}
       >
         <div style={style.controls}>
@@ -73,20 +72,14 @@ class ManifestComponent extends React.Component {
   }
 
   renderAction(action, index) {
-    let newState, oldState, diff;
-    if (index !== 0) {
-      newState = Immutable.Map(this.props.computedStates[index].state).toJS();
-      oldState = Immutable.Map(this.props.computedStates[index - 1].state).toJS();
-      diff = deep.diff(oldState, newState);
-    }
-
+    const diffedStates = diffState(this.props.computedStates, index);
     const skippingAction = this.props.skippedActions[index]===true;
 
     return (
       <ManifestAction action={action}
                       index={index}
                       key={index}
-                      diff={diff || []}
+                      diff={diffedStates}
                       skipped={skippingAction}
                       toggleAction={this.props.toggleAction.bind(this, index)}
                       jumpTo={this.jumpingTo.bind(this, index)}/>

--- a/src/utils/diff-state.js
+++ b/src/utils/diff-state.js
@@ -1,0 +1,21 @@
+import deep from 'deep-diff';
+import Immutable from 'immutable';
+
+export default (computedStates, index) => {
+  if (index !== 0) {
+
+    const newState = Immutable.fromJS({
+      state: computedStates[index].state
+    }).toJS().state;
+
+    const oldState = Immutable.fromJS({
+      state: computedStates[index - 1].state
+    }).toJS().state;
+
+    const diff = deep.diff(oldState, newState);
+
+    return diff || [];
+  } else {
+    return [];
+  }
+};

--- a/test/action/index.spec.js
+++ b/test/action/index.spec.js
@@ -1,0 +1,152 @@
+import { expect } from 'chai';
+import React from 'react/addons';
+import ManifestActionComponent from '../../src/action/index';
+const TestUtils = React.addons.TestUtils;
+
+describe('ManifestActionComponent', () => {
+  const props = {
+    action: {
+      type: 'ACTION_1'
+    },
+    diff: [],
+    expanded: true
+  };
+
+  const render = (props) => {
+    const element = React.createElement(ManifestActionComponent, props);
+
+    return TestUtils.renderIntoDocument(element);
+  };
+
+  it('should show actions', () => {
+    const rendered = render(props);
+
+    expect(
+        React.findDOMNode(rendered).querySelectorAll('.ACTION_1')
+    ).to.have.length(1);
+  });
+
+  describe('diff', () => {
+
+    it('should show no diff if the data has not changed', () => {
+      const rendered = render(props);
+
+      expect(
+          React.findDOMNode(rendered).querySelectorAll('.diff')
+      ).to.have.length(0);
+    });
+
+    it('should show the correct diff when comparing objects having other properties', () => {
+      const rendered = render(Object.assign({}, props, {
+        diff: [ { kind: 'E', path: [ 'key' ], lhs: {}, rhs: {
+          other: 'property',
+          another: 13.13
+        } } ]
+      }));
+
+      expect(
+          React.findDOMNode(rendered).querySelectorAll('.diff')[0].textContent.trim()
+      ).to.eql('key: {} {"other":"property","another":13.13}');
+    });
+
+    it('should show the correct diff when replacing an object with an empty object', () => {
+      const rendered = render(Object.assign({}, props, {
+        diff: [ { kind: 'D', path: [ 'one' ], lhs: 'property' } ]
+      }));
+
+      expect(
+          React.findDOMNode(rendered).querySelectorAll('.diff')[0].textContent.trim()
+      ).to.eql('one: "property"');
+    });
+
+    it('should show the correct diff when comparing changes in nested objects', () => {
+      const rendered = render(Object.assign({}, props, {
+        diff: [ { kind: 'E', path: [ 'levelOne', 'levelTwo' ], lhs: 'value', rhs: 'another value' } ]
+      }));
+
+      expect(
+          React.findDOMNode(rendered).querySelectorAll('.diff')[0].textContent.trim()
+      ).to.eql('levelOne.levelTwo: "value" "another value"');
+    });
+
+    it('should show the correct diff when comparing changes in arrays', () => {
+      const rendered = render(Object.assign({}, props, {
+        diff: [
+          { kind: 'E', path: [ 0 ], lhs: 1, rhs: 2 },
+          { kind: 'E', path: [ 1 ], lhs: 2, rhs: 3 },
+          { kind: 'E', path: [ 2 ], lhs: 3, rhs: 4 }
+        ]
+      }));
+
+      expect(
+          React.findDOMNode(rendered).querySelectorAll('.diff')[0].textContent.trim()
+      ).to.eql('0: 1 2 1: 2 3 2: 3 4');
+    });
+
+    it('should show the correct diff when comparing changes in arrays inside objects', () => {
+      const rendered = render(Object.assign({}, props, {
+        diff: [
+          { kind: 'E', path: [ 'a', 0 ], lhs: 1, rhs: 2 },
+          { kind: 'E', path: [ 'a', 1 ], lhs: 2, rhs: 3 },
+          { kind: 'E', path: [ 'a', 2 ], lhs: 3, rhs: 4 }
+        ]
+      }));
+
+      expect(
+          React.findDOMNode(rendered).querySelectorAll('.diff')[0].textContent.trim()
+      ).to.eql('a.0: 1 2 a.1: 2 3 a.2: 3 4');
+    });
+
+    it('should show the correct diff when item removed from array', () => {
+      const rendered = render(Object.assign({}, props, {
+        diff: [
+          { kind: 'E', path: [ 0 ], lhs: 1, rhs: 2 },
+          { kind: 'E', path: [ 1 ], lhs: 2, rhs: 3 },
+          { kind: 'A', index: 2, item: { kind: 'D', lhs: 3 } }
+        ]
+      }));
+
+      expect(
+          React.findDOMNode(rendered).querySelectorAll('.diff')[0].textContent.trim()
+      ).to.eql('0: 1 2 1: 2 3 2: 3');
+    });
+
+    it('should show the correct diff when item removed from array inside an object', () => {
+      const rendered = render(Object.assign({}, props, {
+        diff: [
+          { kind: 'E', path: [ 'a', 0 ], lhs: 1, rhs: 2 },
+          { kind: 'E', path: [ 'a', 1 ], lhs: 2, rhs: 3 },
+          { kind: 'A', path: [ 'a' ], index: 2, item: { kind: 'D', lhs: 3 } } ]
+      }));
+
+      expect(
+          React.findDOMNode(rendered).querySelectorAll('.diff')[0].textContent.trim()
+      ).to.eql('a.0: 1 2 a.1: 2 3 a.2: 3');
+    });
+
+    it('should diff items added to an array', () => {
+      const rendered = render(Object.assign({}, props, {
+        diff: [ { kind: 'A', index: 2, item: { kind: 'N', rhs: 3 } } ]
+      }));
+
+      expect(
+          React.findDOMNode(rendered).querySelectorAll('.diff')[0].textContent.trim()
+      ).to.eql('2: undefined 3');
+    });
+
+    it('should diff complex objects', () => {
+      const rendered = render(Object.assign({}, props, {
+        diff: [
+          { kind: 'A', path: [ 'ids' ], index: 0, item: { kind: 'N', rhs: 2 } },
+          { kind: 'A', path: [ 'ids' ], index: 1, item: { kind: 'N', rhs: 3 } },
+          { kind: 'E', path: [ 'turn' ], lhs: 0, rhs: 1 },
+          { kind: 'E', path: [ 'round' ], lhs: 0, rhs: 1 }
+        ]
+      }));
+
+      expect(
+          React.findDOMNode(rendered).querySelectorAll('.diff')[0].textContent.trim()
+      ).to.eql('ids.0: undefined 2 ids.1: undefined 3 turn: 0 1 round: 0 1');
+    });
+  });
+});

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import React from 'react/addons';
+import ManifestComponent from '../src/index';
+const TestUtils = React.addons.TestUtils;
+
+describe('ManifestComponent', () => {
+
+  it('should show actions', () => {
+
+    const element = React.createElement(ManifestComponent, {
+      computedStates: [{}, {}],
+      currentStateIndex: 0,
+      stagedActions: [{}, {}],
+      skippedActions: {},
+      reset: () => {},
+      commit: () => {},
+      rollback: () => {},
+      sweep: () => {},
+      toggleAction: () => {},
+      jumpToState: () => {}
+    });
+
+    const rendered = TestUtils.renderIntoDocument(element);
+    expect(
+        React.findDOMNode(rendered).querySelectorAll('.manifest-action-component')
+    ).to.have.length(2);
+  });
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,4 @@
+--require test/test-utils/dom.js
+--require should
+--reporter nyan
+--recursive

--- a/test/test-utils/dom.js
+++ b/test/test-utils/dom.js
@@ -1,0 +1,26 @@
+var jsdom = require('jsdom')
+
+// setup the simplest document possible
+var doc = jsdom.jsdom('<!doctype html><html><body></body></html>')
+
+// get the window object out of the document
+var win = doc.defaultView;
+
+// set globals for mocha that make access to document and window feel
+// natural in the test environment
+global.document = doc
+global.window = win
+
+// take all properties of the window object and also attach it to the
+// mocha global object
+propagateToGlobal(win)
+
+// from mocha-jsdom https://github.com/rstacruz/mocha-jsdom/blob/master/index.js#L80
+function propagateToGlobal (window) {
+  for (let key in window) {
+    if (!window.hasOwnProperty(key)) continue
+    if (key in global) continue
+
+    global[key] = window[key]
+  }
+}

--- a/test/utils/diff-state.spec.js
+++ b/test/utils/diff-state.spec.js
@@ -1,0 +1,1012 @@
+import { expect } from 'chai';
+import diffState from '../../src/utils/diff-state';
+import Immutable from 'immutable';
+
+describe('diffState', () => {
+  let computedStates = [{}, {}];
+
+  const empty = {};
+
+  describe('Plain JavaScript data', () => {
+
+    describe('A target that has no properties', () => {
+      computedStates[0].state = empty;
+
+      it('shows no differences when compared to another empty object', () => {
+        computedStates[1].state = {};
+
+        const diff = diffState(computedStates, 1);
+
+        expect(diff).to.be.an('array');
+        expect(diff).to.have.length(0);
+      });
+    });
+
+    describe('when compared to a different type of keyless object', () => {
+      const aDate = new Date();
+
+      const comparandTuples = [
+        ['an array', {
+          key: []
+        }],
+        ['an object', {
+          key: {}
+        }],
+        ['a date', {
+          key: aDate
+        }],
+        ['a null', {
+          key: null
+        }]
+      ];
+
+      comparandTuples.forEach(function(lhsTuple) {
+        comparandTuples.forEach(function(rhsTuple) {
+          if (lhsTuple[0] === rhsTuple[0]) {
+            return;
+          }
+
+          it('shows differences when comparing ' + lhsTuple[0] + ' to ' + rhsTuple[0], () => {
+            computedStates[0].state = lhsTuple[1];
+            computedStates[1].state = rhsTuple[1];
+
+            const diff = diffState(computedStates, 1);
+
+            expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"key"');
+
+            if (lhsTuple[0] === comparandTuples[0][0]) {
+              expect(JSON.stringify(diff[0].lhs)).to.eql('[]');
+            } else if (lhsTuple[0] === comparandTuples[1][0]) {
+              expect(JSON.stringify(diff[0].lhs)).to.eql('{}');
+            } else if (lhsTuple[0] === comparandTuples[2][0]) {
+              expect(JSON.stringify(diff[0].lhs)).to.eql('"' + aDate.toISOString() + '"');
+            } else if (lhsTuple[0] === comparandTuples[3][0]) {
+              expect(JSON.stringify(diff[0].lhs)).to.eql('null');
+            }
+
+            if (rhsTuple[0] === comparandTuples[0][0]) {
+              expect(JSON.stringify(diff[0].rhs)).to.eql('[]');
+            } else if (rhsTuple[0] === comparandTuples[1][0]) {
+              expect(JSON.stringify(diff[0].rhs)).to.eql('{}');
+            } else if (rhsTuple[0] === comparandTuples[2][0]) {
+              expect(JSON.stringify(diff[0].rhs)).to.eql('"' + aDate.toISOString() + '"');
+            } else if (rhsTuple[0] === comparandTuples[3][0]) {
+              expect(JSON.stringify(diff[0].rhs)).to.eql('null');
+            }
+          });
+        });
+      });
+    });
+
+    describe('when compared with an object having other properties', () => {
+      computedStates[0].state = empty;
+      computedStates[1].state = {
+        other: 'property',
+        another: 13.13
+      };
+
+      const diff = diffState(computedStates, 1);
+
+      it('the differences are reported', () => {
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"other"');
+        expect(JSON.stringify(diff[0].lhs)).be.undefined;
+        expect(JSON.stringify(diff[0].rhs)).eql('"property"');
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"another"');
+        expect(JSON.stringify(diff[1].lhs)).be.undefined;
+        expect(JSON.stringify(diff[1].rhs)).eql('13.13');
+      });
+
+    });
+
+    describe('A target that has one property', function() {
+      const lhs = {
+        one: 'property'
+      };
+
+      it('shows no differences when compared to itself', function() {
+        computedStates[0].state = lhs;
+        computedStates[1].state = lhs;
+
+        const diff = diffState(computedStates, 1);
+        expect(diff).to.be.an.array;
+        expect(diff).to.have.length(0);
+      });
+
+      it('shows the property as removed when compared to an empty object', function() {
+        computedStates[0].state = lhs;
+        computedStates[1].state = empty;
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"one"');
+        expect(JSON.stringify(diff[0].lhs)).eql('"property"');
+        expect(JSON.stringify(diff[0].rhs)).be.undefined;
+      });
+
+      it('shows the property as edited when compared to an object with null', function() {
+        computedStates[0].state = lhs;
+        computedStates[1].state = {
+          one: null
+        };
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"one"');
+        expect(JSON.stringify(diff[0].lhs)).eql('"property"');
+        expect(JSON.stringify(diff[0].rhs)).eql('null');
+      });
+
+      it('shows the property as edited when compared to an array', function() {
+        computedStates[0].state = lhs;
+        computedStates[1].state = ['one'];
+
+        const diff = diffState(computedStates, 1);
+
+        expect(diff[0].path).to.be.undefined;
+        expect(JSON.stringify(diff[0].lhs)).eql('{"one":"property"}');
+        expect(JSON.stringify(diff[0].rhs)).eql('["one"]');
+      });
+
+    });
+
+    describe('A target that has null value', function() {
+      const lhs = {
+        key: null
+      };
+
+      it('shows no differences when compared to itself', function() {
+        computedStates[0].state = lhs;
+        computedStates[1].state = lhs;
+
+        const diff = diffState(computedStates, 1);
+
+        expect(diff).to.be.an.array;
+        expect(diff).to.have.length(0);
+      });
+
+      it('shows the property as removed when compared to an empty object', function() {
+        computedStates[0].state = lhs;
+        computedStates[1].state = empty;
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"key"');
+        expect(JSON.stringify(diff[0].lhs)).eql('null');
+        expect(JSON.stringify(diff[0].rhs)).be.undefined;
+      });
+
+      it('shows the property is changed when compared to an object that has value', function() {
+        computedStates[0].state = lhs;
+        computedStates[1].state = {
+          key: 'value'
+        };
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"key"');
+        expect(JSON.stringify(diff[0].lhs)).eql('null');
+        expect(JSON.stringify(diff[0].rhs)).eql('"value"');
+      });
+
+      it('shows that an object property is changed when it is set to null', function() {
+        lhs.key = {
+          nested: 'value'
+        };
+
+        computedStates[0].state = lhs;
+        computedStates[1].state = {
+          key: null
+        };
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"key"');
+        expect(JSON.stringify(diff[0].lhs)).eql('{"nested":"value"}');
+        expect(JSON.stringify(diff[0].rhs)).eql('null');
+      });
+
+    });
+
+    describe('A target that has a NaN', function() {
+      const lhs = {
+        key: NaN
+      };
+
+      it('shows the property is changed when compared to another number', function() {
+        computedStates[0].state = lhs;
+        computedStates[1].state = {
+          key: 0
+        };
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"key"');
+        expect(JSON.stringify(diff[0].lhs)).eql('null');
+        expect(JSON.stringify(diff[0].rhs)).eql('0');
+      });
+
+      it('shows no differences when compared to another NaN', function() {
+        computedStates[0].state = lhs;
+        computedStates[1].state = {
+          key: NaN
+        };
+
+        const diff = diffState(computedStates, 1);
+
+        expect(diff).to.be.an.array;
+        expect(diff).to.have.length(0);
+      });
+
+    });
+
+    describe('A target that has nested values', function() {
+      const nestedOne = {
+        noChange: 'same',
+        levelOne: {
+          levelTwo: 'value'
+        }
+      };
+      const nestedTwo = {
+        noChange: 'same',
+        levelOne: {
+          levelTwo: 'another value'
+        }
+      };
+
+      it('shows no differences when compared to itself', function() {
+        computedStates[0].state = nestedOne;
+        computedStates[1].state = nestedOne;
+
+        const diff = diffState(computedStates, 1);
+
+        expect(diff).to.be.an.array;
+        expect(diff).to.have.length(0);
+      });
+
+      it('shows the property as removed when compared to an empty object', function() {
+        computedStates[0].state = nestedOne;
+        computedStates[1].state = empty;
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"noChange"');
+        expect(JSON.stringify(diff[0].lhs)).eql('"same"');
+        expect(JSON.stringify(diff[0].rhs)).to.be.undefined;
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"levelOne"');
+        expect(JSON.stringify(diff[1].lhs)).eql('{"levelTwo":"value"}');
+        expect(JSON.stringify(diff[1].rhs)).be.undefined;
+      });
+
+      it('shows the property is changed when compared to an object that has value', function() {
+        computedStates[0].state = nestedOne;
+        computedStates[1].state = nestedTwo;
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"levelOne.levelTwo"');
+        expect(JSON.stringify(diff[0].lhs)).eql('"value"');
+        expect(JSON.stringify(diff[0].rhs)).eql('"another value"');
+      });
+
+      it('shows the property as added when compared to an empty object on left', function() {
+        computedStates[0].state = empty;
+        computedStates[1].state = nestedOne;
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"noChange"');
+        expect(JSON.stringify(diff[0].lhs)).be.undefined;
+        expect(JSON.stringify(diff[0].rhs)).eql('"same"');
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"levelOne"');
+        expect(JSON.stringify(diff[1].lhs)).to.be.undefined;
+        expect(JSON.stringify(diff[1].rhs)).eql('{"levelTwo":"value"}');
+      });
+    });
+
+    describe('Working with arrays', () => {
+
+      it('should diff items changed in an array', () => {
+        computedStates[0].state = [1, 2, 3];
+        computedStates[1].state = [2, 3, 4];
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"0"');
+        expect(JSON.stringify(diff[0].lhs)).to.eql('1');
+        expect(JSON.stringify(diff[0].rhs)).eql('2');
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"1"');
+        expect(JSON.stringify(diff[1].lhs)).to.eql('2');
+        expect(JSON.stringify(diff[1].rhs)).eql('3');
+
+        expect(JSON.stringify(diff[2].path.join('.'))).to.eql('"2"');
+        expect(JSON.stringify(diff[2].lhs)).to.eql('3');
+        expect(JSON.stringify(diff[2].rhs)).eql('4');
+      });
+
+      it('should diff items changed in an array inside an object', () => {
+        computedStates[0].state = {
+          a: [1, 2, 3]
+        };
+        computedStates[1].state = {
+          a: [2, 3, 4]
+        };
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"a.0"');
+        expect(JSON.stringify(diff[0].lhs)).to.eql('1');
+        expect(JSON.stringify(diff[0].rhs)).eql('2');
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"a.1"');
+        expect(JSON.stringify(diff[1].lhs)).to.eql('2');
+        expect(JSON.stringify(diff[1].rhs)).eql('3');
+
+        expect(JSON.stringify(diff[2].path.join('.'))).to.eql('"a.2"');
+        expect(JSON.stringify(diff[2].lhs)).to.eql('3');
+        expect(JSON.stringify(diff[2].rhs)).eql('4');
+      });
+
+      it('should diff when item removed from array', () => {
+        computedStates[0].state = [1, 2, 3];
+        computedStates[1].state = [2, 3];
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"0"');
+        expect(JSON.stringify(diff[0].lhs)).to.eql('1');
+        expect(JSON.stringify(diff[0].rhs)).eql('2');
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"1"');
+        expect(JSON.stringify(diff[1].lhs)).to.eql('2');
+        expect(JSON.stringify(diff[1].rhs)).eql('3');
+
+        expect(JSON.stringify(diff[2].index)).to.eql('2');
+        expect(JSON.stringify(diff[2].item.lhs)).to.eql('3');
+        expect(JSON.stringify(diff[2].item.rhs)).be.undefined;
+      });
+
+      it('should diff item removed from an array inside an object', () => {
+        computedStates[0].state = {
+          a: [1, 2, 3]
+        };
+        computedStates[1].state = {
+          a: [2, 3]
+        };
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"a.0"');
+        expect(JSON.stringify(diff[0].lhs)).to.eql('1');
+        expect(JSON.stringify(diff[0].rhs)).eql('2');
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"a.1"');
+        expect(JSON.stringify(diff[1].lhs)).to.eql('2');
+        expect(JSON.stringify(diff[1].rhs)).eql('3');
+
+        expect(JSON.stringify(diff[2].path.join('.'))).to.eql('"a"');
+        expect(JSON.stringify(diff[2].index)).to.eql('2');
+        expect(JSON.stringify(diff[2].item.lhs)).to.eql('3');
+        expect(JSON.stringify(diff[2].item.rhs)).be.undefined;
+      });
+
+      it('should diff items added to an array', () => {
+        computedStates[0].state = [1, 2];
+        computedStates[1].state = [1, 2, 3];
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].index)).to.eql('2');
+        expect(JSON.stringify(diff[0].item.lhs)).to.be.undefined;
+        expect(JSON.stringify(diff[0].item.rhs)).eql('3');
+      });
+
+      it('should diff item added to an array inside an object', () => {
+        computedStates[0].state = {
+          a: [1, 2]
+        };
+        computedStates[1].state = {
+          a: [2, 3, 4]
+        };
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"a.0"');
+        expect(JSON.stringify(diff[0].lhs)).to.eql('1');
+        expect(JSON.stringify(diff[0].rhs)).eql('2');
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"a.1"');
+        expect(JSON.stringify(diff[1].lhs)).to.eql('2');
+        expect(JSON.stringify(diff[1].rhs)).eql('3');
+
+        expect(JSON.stringify(diff[2].path.join('.'))).to.eql('"a"');
+        expect(JSON.stringify(diff[2].index)).to.eql('2');
+        expect(JSON.stringify(diff[2].item.lhs)).to.be.undefined;
+        expect(JSON.stringify(diff[2].item.rhs)).to.eql('4');
+      });
+    });
+
+  });
+
+  describe('ImmutableJS data', () => {
+    let computedStates = [{}, {}];
+
+    const empty = Immutable.Map();
+
+    describe('A target that has no properties', () => {
+      computedStates[0].state = empty;
+
+      it('shows no differences when compared to another empty object', () => {
+        computedStates[1].state = Immutable.Map();
+
+        const diff = diffState(computedStates, 1);
+
+        expect(diff).to.be.an('array');
+        expect(diff).to.have.length(0);
+      });
+    });
+
+    describe('when compared to a different type of keyless object', () => {
+      const aDate = new Date();
+
+      const comparandTuples = [
+        ['an array', {
+          key: Immutable.fromJS([])
+        }],
+        ['an object', {
+          key: Immutable.fromJS({})
+        }],
+        ['a date', {
+          key: Immutable.fromJS(aDate)
+        }],
+        ['a null', {
+          key: Immutable.fromJS(null)
+        }],
+        ['a regexp literal', {
+          key: Immutable.fromJS(/a/)
+        }]
+      ];
+
+      comparandTuples.forEach(function(lhsTuple) {
+        comparandTuples.forEach(function(rhsTuple) {
+          if (lhsTuple[0] === rhsTuple[0]) {
+            return;
+          }
+
+          it('shows differences when comparing ' + lhsTuple[0] + ' to ' + rhsTuple[0], () => {
+            computedStates[0].state = lhsTuple[1];
+            computedStates[1].state = rhsTuple[1];
+
+            const diff = diffState(computedStates, 1);
+
+            expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"key"');
+
+            if (lhsTuple[0] === comparandTuples[0][0]) {
+              expect(JSON.stringify(diff[0].lhs)).to.eql('[]');
+            } else if (lhsTuple[0] === comparandTuples[1][0]) {
+              expect(JSON.stringify(diff[0].lhs)).to.eql('{}');
+            } else if (lhsTuple[0] === comparandTuples[2][0]) {
+              expect(JSON.stringify(diff[0].lhs)).to.eql('"' + aDate.toISOString() + '"');
+            } else if (lhsTuple[0] === comparandTuples[3][0]) {
+              expect(JSON.stringify(diff[0].lhs)).to.eql('null');
+            }
+
+            if (rhsTuple[0] === comparandTuples[0][0]) {
+              expect(JSON.stringify(diff[0].rhs)).to.eql('[]');
+            } else if (rhsTuple[0] === comparandTuples[1][0]) {
+              expect(JSON.stringify(diff[0].rhs)).to.eql('{}');
+            } else if (rhsTuple[0] === comparandTuples[2][0]) {
+              expect(JSON.stringify(diff[0].rhs)).to.eql('"' + aDate.toISOString() + '"');
+            } else if (rhsTuple[0] === comparandTuples[3][0]) {
+              expect(JSON.stringify(diff[0].rhs)).to.eql('null');
+            }
+          });
+        });
+      });
+    });
+
+    describe('when compared with an object having other properties', () => {
+      computedStates[0].state = empty;
+      computedStates[1].state = Immutable.fromJS({
+        other: 'property',
+        another: 13.13
+      });
+
+      const diff = diffState(computedStates, 1);
+
+      it('the differences are reported', () => {
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"other"');
+        expect(JSON.stringify(diff[0].lhs)).be.undefined;
+        expect(JSON.stringify(diff[0].rhs)).eql('"property"');
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"another"');
+        expect(JSON.stringify(diff[1].lhs)).be.undefined;
+        expect(JSON.stringify(diff[1].rhs)).eql('13.13');
+      });
+
+    });
+
+    describe('A target that has one property', function() {
+      const lhs = Immutable.fromJS({
+        one: 'property'
+      });
+
+      it('shows no differences when compared to itself', function() {
+        computedStates[0].state = lhs;
+        computedStates[1].state = lhs;
+
+        const diff = diffState(computedStates, 1);
+        expect(diff).to.be.an.array;
+        expect(diff).to.have.length(0);
+      });
+
+      it('shows the property as removed when compared to an empty object', function() {
+        computedStates[0].state = lhs;
+        computedStates[1].state = empty;
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"one"');
+        expect(JSON.stringify(diff[0].lhs)).eql('"property"');
+        expect(JSON.stringify(diff[0].rhs)).be.undefined;
+      });
+
+      it('shows the property as edited when compared to an object with null', function() {
+        computedStates[0].state = lhs;
+        computedStates[1].state = Immutable.fromJS({
+          one: null
+        });
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"one"');
+        expect(JSON.stringify(diff[0].lhs)).eql('"property"');
+        expect(JSON.stringify(diff[0].rhs)).eql('null');
+      });
+
+      it('shows the property as edited when compared to an array', function() {
+        computedStates[0].state = lhs;
+        computedStates[1].state = Immutable.fromJS(['one']);
+
+        const diff = diffState(computedStates, 1);
+
+        expect(diff[0].path).to.be.undefined;
+        expect(JSON.stringify(diff[0].lhs)).eql('{"one":"property"}');
+        expect(JSON.stringify(diff[0].rhs)).eql('["one"]');
+      });
+
+    });
+
+    describe('A target that has null value', function() {
+      const lhs = Immutable.fromJS({
+        key: null
+      });
+
+      it('shows no differences when compared to itself', function() {
+        computedStates[0].state = lhs;
+        computedStates[1].state = lhs;
+
+        const diff = diffState(computedStates, 1);
+
+        expect(diff).to.be.an.array;
+        expect(diff).to.have.length(0);
+      });
+
+      it('shows the property as removed when compared to an empty object', function() {
+        computedStates[0].state = lhs;
+        computedStates[1].state = empty;
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"key"');
+        expect(JSON.stringify(diff[0].lhs)).eql('null');
+        expect(JSON.stringify(diff[0].rhs)).be.undefined;
+      });
+
+      it('shows the property is changed when compared to an object that has value', function() {
+        computedStates[0].state = lhs;
+        computedStates[1].state = Immutable.fromJS({
+          key: 'value'
+        });
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"key"');
+        expect(JSON.stringify(diff[0].lhs)).eql('null');
+        expect(JSON.stringify(diff[0].rhs)).eql('"value"');
+      });
+
+      it('shows that an object property is changed when it is set to null', function() {
+        computedStates[0].state = lhs.set('key', {
+          nested: 'value'
+        });
+        computedStates[1].state = Immutable.fromJS({
+          key: null
+        });
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"key"');
+        expect(JSON.stringify(diff[0].lhs)).eql('{"nested":"value"}');
+        expect(JSON.stringify(diff[0].rhs)).eql('null');
+      });
+
+    });
+
+
+    describe('A target that has a NaN', function() {
+      const lhs = Immutable.fromJS({
+        key: NaN
+      });
+
+      it('shows the property is changed when compared to another number', function() {
+        computedStates[0].state = lhs;
+        computedStates[1].state = Immutable.fromJS({
+          key: 0
+        });
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"key"');
+        expect(JSON.stringify(diff[0].lhs)).eql('null');
+        expect(JSON.stringify(diff[0].rhs)).eql('0');
+      });
+
+      it('shows no differences when compared to another NaN', function() {
+        computedStates[0].state = lhs;
+        computedStates[1].state = Immutable.fromJS({
+          key: NaN
+        });
+
+        const diff = diffState(computedStates, 1);
+
+        expect(diff).to.be.an.array;
+        expect(diff).to.have.length(0);
+      });
+
+    });
+
+    describe('A target that has nested values', function() {
+      const nestedOne = Immutable.fromJS({
+        noChange: 'same',
+        levelOne: {
+          levelTwo: 'value'
+        }
+      });
+      const nestedTwo = Immutable.fromJS({
+        noChange: 'same',
+        levelOne: {
+          levelTwo: 'another value'
+        }
+      });
+
+      it('shows no differences when compared to itself', function() {
+        computedStates[0].state = nestedOne;
+        computedStates[1].state = nestedOne;
+
+        const diff = diffState(computedStates, 1);
+
+        expect(diff).to.be.an.array;
+        expect(diff).to.have.length(0);
+      });
+
+      it('shows the property as removed when compared to an empty object', function() {
+        computedStates[0].state = nestedOne;
+        computedStates[1].state = empty;
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"noChange"');
+        expect(JSON.stringify(diff[0].lhs)).eql('"same"');
+        expect(JSON.stringify(diff[0].rhs)).to.be.undefined;
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"levelOne"');
+        expect(JSON.stringify(diff[1].lhs)).eql('{"levelTwo":"value"}');
+        expect(JSON.stringify(diff[1].rhs)).be.undefined;
+      });
+
+      it('shows the property is changed when compared to an object that has value', function() {
+        computedStates[0].state = nestedOne;
+        computedStates[1].state = nestedTwo;
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"levelOne.levelTwo"');
+        expect(JSON.stringify(diff[0].lhs)).eql('"value"');
+        expect(JSON.stringify(diff[0].rhs)).eql('"another value"');
+      });
+
+      it('shows the property as added when compared to an empty object on left', function() {
+        computedStates[0].state = empty;
+        computedStates[1].state = nestedOne;
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"noChange"');
+        expect(JSON.stringify(diff[0].lhs)).be.undefined;
+        expect(JSON.stringify(diff[0].rhs)).eql('"same"');
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"levelOne"');
+        expect(JSON.stringify(diff[1].lhs)).to.be.undefined;
+        expect(JSON.stringify(diff[1].rhs)).eql('{"levelTwo":"value"}');
+      });
+    });
+
+    describe('Immutable data in plain objects', function() {
+
+      describe('Single level Immutable objects one level deep in plain object', () => {
+
+        const nestedOne = {
+          a: Immutable.fromJS({
+            one: 'something'
+          })
+        };
+
+        const nestedTwo = {
+          a: Immutable.fromJS({
+            one: 'somethingElse'
+          })
+        };
+
+        it('shows the property is changed when compared to an object that has value', () => {
+          computedStates[0].state = nestedOne;
+          computedStates[1].state = nestedTwo;
+
+          const diff = diffState(computedStates, 1);
+
+          expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"a.one"');
+          expect(JSON.stringify(diff[0].lhs)).eql('"something"');
+          expect(JSON.stringify(diff[0].rhs)).eql('"somethingElse"');
+        });
+      });
+
+      describe('Nested Immutable objects one level deep in plain object', () => {
+
+        const nestedOne = {
+          a: Immutable.fromJS({
+            one: {
+              two: 'something'
+            }
+          })
+        };
+
+        const nestedTwo = {
+          a: Immutable.fromJS({
+            one: {
+              two: 'somethingElse'
+            }
+          })
+        };
+
+        const nestedThree = {
+          a: Immutable.fromJS({
+            one: {
+              two: 'somethingElse'
+            },
+            three: {
+              four: "cheese"
+            }
+          })
+        };
+
+        it('shows the property is changed when compared to an object that has value', () => {
+          computedStates[0].state = nestedOne;
+          computedStates[1].state = nestedTwo;
+
+          const diff = diffState(computedStates, 1);
+
+          expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"a.one.two"');
+          expect(JSON.stringify(diff[0].lhs)).eql('"something"');
+          expect(JSON.stringify(diff[0].rhs)).eql('"somethingElse"');
+        });
+
+        it('shows properties change when compared to an object that has value', () => {
+          computedStates[0].state = nestedOne;
+          computedStates[1].state = nestedThree;
+
+          const diff = diffState(computedStates, 1);
+
+          expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"a.one.two"');
+          expect(JSON.stringify(diff[0].lhs)).eql('"something"');
+          expect(JSON.stringify(diff[0].rhs)).eql('"somethingElse"');
+
+          expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"a.three"');
+          expect(JSON.stringify(diff[1].lhs)).to.be.undefined;
+          expect(JSON.stringify(diff[1].rhs)).eql('{"four":"cheese"}');
+        })
+      });
+    });
+
+    describe('Working with arrays', () => {
+
+      it('should diff items changed in an array', () => {
+        computedStates[0].state = Immutable.List([1, 2, 3]);
+        computedStates[1].state = Immutable.List([2, 3, 4]);
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"0"');
+        expect(JSON.stringify(diff[0].lhs)).to.eql('1');
+        expect(JSON.stringify(diff[0].rhs)).eql('2');
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"1"');
+        expect(JSON.stringify(diff[1].lhs)).to.eql('2');
+        expect(JSON.stringify(diff[1].rhs)).eql('3');
+
+        expect(JSON.stringify(diff[2].path.join('.'))).to.eql('"2"');
+        expect(JSON.stringify(diff[2].lhs)).to.eql('3');
+        expect(JSON.stringify(diff[2].rhs)).eql('4');
+      });
+
+      it('should diff items changed in an array inside an object', () => {
+        computedStates[0].state = {
+          a: Immutable.List([1, 2, 3])
+        };
+        computedStates[1].state = {
+          a: Immutable.List([2, 3, 4])
+        };
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"a.0"');
+        expect(JSON.stringify(diff[0].lhs)).to.eql('1');
+        expect(JSON.stringify(diff[0].rhs)).eql('2');
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"a.1"');
+        expect(JSON.stringify(diff[1].lhs)).to.eql('2');
+        expect(JSON.stringify(diff[1].rhs)).eql('3');
+
+        expect(JSON.stringify(diff[2].path.join('.'))).to.eql('"a.2"');
+        expect(JSON.stringify(diff[2].lhs)).to.eql('3');
+        expect(JSON.stringify(diff[2].rhs)).eql('4');
+      });
+
+      it('should diff items changed in an array inside a map', () => {
+        computedStates[0].state = Immutable.Map({
+          a: [1, 2, 3]
+        });
+        computedStates[1].state = Immutable.Map({
+          a: [2, 3, 4]
+        });
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"a.0"');
+        expect(JSON.stringify(diff[0].lhs)).to.eql('1');
+        expect(JSON.stringify(diff[0].rhs)).eql('2');
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"a.1"');
+        expect(JSON.stringify(diff[1].lhs)).to.eql('2');
+        expect(JSON.stringify(diff[1].rhs)).eql('3');
+
+        expect(JSON.stringify(diff[2].path.join('.'))).to.eql('"a.2"');
+        expect(JSON.stringify(diff[2].lhs)).to.eql('3');
+        expect(JSON.stringify(diff[2].rhs)).eql('4');
+      });
+
+      it('should diff when item removed from array', () => {
+        computedStates[0].state = Immutable.List([1, 2, 3]);
+        computedStates[1].state = Immutable.List([2, 3]);
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"0"');
+        expect(JSON.stringify(diff[0].lhs)).to.eql('1');
+        expect(JSON.stringify(diff[0].rhs)).eql('2');
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"1"');
+        expect(JSON.stringify(diff[1].lhs)).to.eql('2');
+        expect(JSON.stringify(diff[1].rhs)).eql('3');
+
+        expect(JSON.stringify(diff[2].index)).to.eql('2');
+        expect(JSON.stringify(diff[2].item.lhs)).to.eql('3');
+        expect(JSON.stringify(diff[2].item.rhs)).be.undefined;
+      });
+
+      it('should diff item removed from an array inside an object', () => {
+        computedStates[0].state = {
+          a: Immutable.List([1, 2, 3])
+        };
+        computedStates[1].state = {
+          a: Immutable.List([2, 3])
+        };
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"a.0"');
+        expect(JSON.stringify(diff[0].lhs)).to.eql('1');
+        expect(JSON.stringify(diff[0].rhs)).eql('2');
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"a.1"');
+        expect(JSON.stringify(diff[1].lhs)).to.eql('2');
+        expect(JSON.stringify(diff[1].rhs)).eql('3');
+
+        expect(JSON.stringify(diff[2].path.join('.'))).to.eql('"a"');
+        expect(JSON.stringify(diff[2].index)).to.eql('2');
+        expect(JSON.stringify(diff[2].item.lhs)).to.eql('3');
+        expect(JSON.stringify(diff[2].item.rhs)).be.undefined;
+      });
+
+      it('should diff items added to an array', () => {
+        computedStates[0].state = Immutable.List([1, 2]);
+        computedStates[1].state = Immutable.List([2, 3, 4]);
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"0"');
+        expect(JSON.stringify(diff[0].lhs)).to.eql('1');
+        expect(JSON.stringify(diff[0].rhs)).eql('2');
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"1"');
+        expect(JSON.stringify(diff[1].lhs)).to.eql('2');
+        expect(JSON.stringify(diff[1].rhs)).eql('3');
+
+        expect(JSON.stringify(diff[2].index)).to.eql('2');
+        expect(JSON.stringify(diff[2].item.lhs)).to.be.undefined;
+        expect(JSON.stringify(diff[2].item.rhs)).eql('4');
+      });
+
+      it('should diff item added to an array inside an object', () => {
+        computedStates[0].state = {
+          a: Immutable.List([1, 2])
+        };
+        computedStates[1].state = {
+          a: Immutable.List([2, 3, 4])
+        };
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"a.0"');
+        expect(JSON.stringify(diff[0].lhs)).to.eql('1');
+        expect(JSON.stringify(diff[0].rhs)).eql('2');
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"a.1"');
+        expect(JSON.stringify(diff[1].lhs)).to.eql('2');
+        expect(JSON.stringify(diff[1].rhs)).eql('3');
+
+        expect(JSON.stringify(diff[2].path.join('.'))).to.eql('"a"');
+        expect(JSON.stringify(diff[2].index)).to.eql('2');
+        expect(JSON.stringify(diff[2].item.lhs)).to.be.undefined;
+        expect(JSON.stringify(diff[2].item.rhs)).to.eql('4');
+      });
+
+      it('should diff complex object', () => {
+        computedStates[0].state = Immutable.Map({
+          ids: [],
+          turn: 0,
+          round: 0
+        });
+        computedStates[1].state = Immutable.Map({
+          ids: [2,3],
+          turn:1,
+          round: 1
+        });
+
+        const diff = diffState(computedStates, 1);
+
+        expect(JSON.stringify(diff[0].path.join('.'))).to.eql('"ids"');
+        expect(JSON.stringify(diff[0].index)).to.eql('0');
+        expect(JSON.stringify(diff[0].item.lhs)).to.be.undefined;
+        expect(JSON.stringify(diff[0].item.rhs)).eql('2');
+
+        expect(JSON.stringify(diff[1].path.join('.'))).to.eql('"ids"');
+        expect(JSON.stringify(diff[1].index)).to.eql('1');
+        expect(JSON.stringify(diff[1].item.lhs)).to.be.undefined;
+        expect(JSON.stringify(diff[1].item.rhs)).eql('3');
+
+        expect(JSON.stringify(diff[2].path.join('.'))).to.eql('"turn"');
+        expect(JSON.stringify(diff[2].lhs)).to.eql('0');
+        expect(JSON.stringify(diff[2].rhs)).to.eql('1');
+
+        expect(JSON.stringify(diff[3].path.join('.'))).to.eql('"round"');
+        expect(JSON.stringify(diff[3].lhs)).to.eql('0');
+        expect(JSON.stringify(diff[3].rhs)).to.eql('1');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/whetstone/redux-devtools-diff-monitor/issues/16.

The issue wasn't actually Immutable related and occurred with plain JavaScript objects as well. Rather it was to do with the data coming back from deep-diff.

deep-diff returns an array for each change between two pieces of data. For all data types, and for items that change value in an array, each item in the diff array has 'path', 'lhs', and 'rhs' properties.

However, when items are removed or deleted from arrays, items in the diff array for these changes have 'index' and 'item' properties, with 'lhs' and 'rhs' inside the 'item'. They do not necessarily have 'path' properties;

e.g https://github.com/theSmaw/redux-devtools-diff-monitor/blob/2b2ffadb421abf6904c41fc80b7aaba8374b4c7c/test/utils/diff-state.spec.js#L397-L406

I have had to tweak the creation of newState, oldState and path to handle these different data structures:

https://github.com/theSmaw/redux-devtools-diff-monitor/blob/2b2ffadb421abf6904c41fc80b7aaba8374b4c7c/src/action/index.js#L29-L55

I have extracted diffState from ManifestComponent to make the diffing more easily testable. I have then covered ManfiestActionComponent with tests to ensure that the results of the diff are correctly built up for output to the screen. There is now good coverage for various data changes for both plain JavaScript and Immutable data.

The results of this PR seem to work well now with @ingro's use case, and still work well with the Todo example, and within my own project.

![screen shot on 2015-09-30 at 13-10-23](https://cloud.githubusercontent.com/assets/429802/10192905/97ada6ee-6777-11e5-86af-7166d29c3a27.png)

![screen shot on 2015-09-30 at 13-12-39](https://cloud.githubusercontent.com/assets/429802/10192896/90ec9946-6777-11e5-9aa3-3157e6d70ce2.png)

