### PR TITLE
Make react / react-dom peer dependencies and support react 15.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "jsdom": "3.1.2",
     "mocha": "^2.3.3",
     "react-addons-test-utils": "^0.14.5",
-    "react-dom": "^0.14.5",
     "rimraf": "^2.5.0",
     "should": "^7.1.0"
   },
@@ -36,9 +35,12 @@
     "deep-diff": "^0.3.2",
     "immutable": "^3.7.6",
     "radium": "^0.13.5",
-    "react": "^0.14.0",
     "react-redux": "^3.1.0",
     "redux": "^3.0.2",
     "redux-devtools": "^3.0.0"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0 || ^15.0.0",
+    "react-dom": "^0.14.5 || ^15.0.0"
   }
 }


### PR DESCRIPTION
Having react and react-dom as dependencies causes multiple versions of React in bundlers.  It seems to be the norm to make them peer dependencies.  Any reason for not doing this?