### PR TITLE
Check skipped for shouldComponentUpdate

### DIFF
--- a/src/action/index.js
+++ b/src/action/index.js
@@ -20,7 +20,9 @@ class ManifestActionComponent extends React.Component {
   shouldComponentUpdate(nextProps, nextState) {
     const a = JSON.stringify(this.props.currentState);
     const b = JSON.stringify(nextProps.currentState);
-    return a !== b || this.state.expanded !== nextState.expanded;
+    return a !== b ||
+      this.state.expanded !== nextState.expanded ||
+      this.props.skipped !== nextProps.skipped;
   }
 
   getDiffs() {


### PR DESCRIPTION
When I disable action, if action isn't expanded, it will not update action component.