### PR TITLE
Remove deprecated usage of React.PropTypes

### DIFF
--- a/examples/todomvc-livewire/components/Footer.js
+++ b/examples/todomvc-livewire/components/Footer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { SHOW_ALL, SHOW_MARKED, SHOW_UNMARKED } from '../constants/TodoFilters';
 

--- a/examples/todomvc-livewire/components/Header.js
+++ b/examples/todomvc-livewire/components/Header.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import TodoTextInput from './TodoTextInput';
 
 export default class Header extends Component {

--- a/examples/todomvc-livewire/components/MainSection.js
+++ b/examples/todomvc-livewire/components/MainSection.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import TodoItem from './TodoItem';
 import Footer from './Footer';
 import { SHOW_ALL, SHOW_MARKED, SHOW_UNMARKED } from '../constants/TodoFilters';

--- a/examples/todomvc-livewire/components/TodoItem.js
+++ b/examples/todomvc-livewire/components/TodoItem.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import TodoTextInput from './TodoTextInput';
 

--- a/examples/todomvc-livewire/components/TodoTextInput.js
+++ b/examples/todomvc-livewire/components/TodoTextInput.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 export default class TodoTextInput extends Component {

--- a/examples/todomvc/components/Footer.js
+++ b/examples/todomvc/components/Footer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { SHOW_ALL, SHOW_MARKED, SHOW_UNMARKED } from '../constants/TodoFilters';
 

--- a/examples/todomvc/components/Header.js
+++ b/examples/todomvc/components/Header.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import TodoTextInput from './TodoTextInput';
 
 export default class Header extends Component {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "aphrodite": "^0.2.0",
     "deep-diff": "^0.3.2",
     "immutable": "^3.7.6",
+    "prop-types": "^15.5.10",
     "react-json-tree": "^0.6.5"
   },
   "peerDependencies": {

--- a/src/action/index.js
+++ b/src/action/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { StyleSheet, css } from 'aphrodite';
 import JSONTree from 'react-json-tree';
 

--- a/src/button/index.js
+++ b/src/button/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { StyleSheet, css } from 'aphrodite';
 
 const ManifestButton = ({ label, action }) => (

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ManifestAction from './action';
 import ManifestButton from './button';
 import diffState from './utils/diff-state';


### PR DESCRIPTION
* Removed deprecated usage of `PropTypes` from the react package, per https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes